### PR TITLE
Adding back telnet

### DIFF
--- a/star_wars/Dockerfile
+++ b/star_wars/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:latest
 
-MAINTAINER Brent Salisbury <brent.salisbury@gmail.com>
+LABEL MAINTAINER="Brent Salisbury <brent.salisbury@gmail.com>"
+
+RUN apk add --no-cache busybox-extras
 
 # Bored with "Hello World" for a test container run?
 # Spruce up your Docker terminal with an ASCII version


### PR DESCRIPTION
Alpine dropped telnet. The package `busybox-extras` adds it back. This PR restores the functionality (and glory) to this masterpiece. Also updated "MAINTAINER" to conform to the label pattern.